### PR TITLE
feat: typeorm timezone 설정 추가

### DIFF
--- a/src/common/scheduled/tasks.service.ts
+++ b/src/common/scheduled/tasks.service.ts
@@ -6,12 +6,13 @@ import { UserService } from 'src/models/user/user.service';
 export class TasksService {
   constructor(private usersService: UserService) {}
 
-  @Cron(CronExpression.EVERY_5_MINUTES)
+  //
+  @Cron(CronExpression.EVERY_MINUTE)
   async removeExpiredTokens() {
     const currentTime = new Date().getTime();
     const usersWithExpiredTokens =
       await this.usersService.findUsersWithExpiredTokens(currentTime);
-    console.log('hi', usersWithExpiredTokens);
+    // console.log('list', usersWithExpiredTokens);
     for (const user of usersWithExpiredTokens) {
       if (user.currentRefreshToken) {
         await this.usersService.removeRefreshToken(user.id);

--- a/src/database/database.module.ts
+++ b/src/database/database.module.ts
@@ -15,7 +15,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
         database: configService.get<string>('DB_NAME'),
         autoLoadEntities: true,
         synchronize: configService.get<boolean>('DB_SYNCHRONIZE'), // 상용 서버에서는 false로 바꿔야함
-        timezone: 'UTC',
+        timezone: 'z',
         logging: true,
       }),
       inject: [ConfigService],

--- a/src/models/user/entities/user.entity.ts
+++ b/src/models/user/entities/user.entity.ts
@@ -1,0 +1,37 @@
+import { Role } from 'src/common/enums/role.enum';
+import { Good } from 'src/models/goods/entities/good.entity';
+import { Entity, Column, PrimaryGeneratedColumn, OneToMany } from 'typeorm';
+
+@Entity()
+export class User {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column({ unique: true })
+  email!: string;
+
+  @Column()
+  username!: string;
+
+  @Column({ select: false })
+  password?: string;
+
+  @Column({ default: Role.User })
+  role: string;
+
+  @OneToMany(() => Good, (good) => good.user)
+  goods: Good[];
+
+  @Column({ name: 'current_refresh_token', nullable: true })
+  currentRefreshToken: string;
+
+  @Column({
+    name: 'current_refresh_token_exp',
+    type: 'timestamp',
+    nullable: true,
+  })
+  currentRefreshTokenExp: Date;
+
+  @Column({ name: 'created_at', type: 'timestamp' })
+  createdAt: Date = new Date();
+}

--- a/src/models/user/user.repository.ts
+++ b/src/models/user/user.repository.ts
@@ -75,8 +75,8 @@ export class UserRepository {
   }
 
   async findUsersWithExpiredTokens(currentTime: number): Promise<User[]> {
-    const queryBuilder = this.userRepository.createQueryBuilder('user');
-    const usersWithExpiredTokens = await queryBuilder
+    const usersWithExpiredTokens = this.userRepository
+      .createQueryBuilder('user')
       .where('user.currentRefreshTokenExp <= :currentTime', {
         currentTime: new Date(currentTime),
       })


### PR DESCRIPTION
## 구현
create_at 필드에 들어가는 형식이 로컬 서버의 시간대에서 UTC의 형식으로 바꾼 것이여서
ex) 현재 시간(서울)이 오전 12:27분이면, 2024-01-02T00:27:49.995Z 로 들어감.
내 생각에는 한국 시간 UTC +9 이므로 -9를 해서 UTC +0인 2024-01-02T15:27:49.995Z 시간이 아니라

그래서 현재 UTC +0 으로 timestamp가 들어가게 수정해놓음

## 특이 사항
서버의 시간대 현재는 UTC로 보임, DB는 잘 모르겟음
여기서 서버의 시간대를 내가 생각했을 때는, Asia/seoul로 올리면,
아마 저장이 new Date() 하면 지금 로컬 서버의 시간에서 +9가 될 것 같음. 그러면 DB에도 UTC로 저장되는 것이 아닐 것임. 흠… 

이어서 생각하면, 
실 서버를 올렸을 때, 만약 UTC :00 으로 저장되지 않고, +9로 저장이 된다면.. new Date() 하는 곳에서 -9 하는 로직이 필요해 보임.